### PR TITLE
Refactor client.js to remove Netflix dependency

### DIFF
--- a/failure-1.12.4/client.js
+++ b/failure-1.12.4/client.js
@@ -2,43 +2,51 @@ var PROTO_PATH = __dirname + '/../common/echo_service.proto';
 
 var grpc = require('grpc');
 var echo_proto = grpc.load(PROTO_PATH);
-var echoServices = echo_proto.com.netflix.EchoService;
-var echoMessages = echo_proto.com.netflix.EchoMessage;
-const netflixGrpcRuntimeCore = require('netflix-grpc-runtime-core');
+var EchoService = echo_proto.com.netflix.EchoService;
+var EchoMessage = echo_proto.com.netflix.EchoMessage;
 
-const serverEndpoints = {
-  dns: 'grpcechoservice.us-east-1.dyntest.netflix.net:8980',
-};
+const serverDnsAddr = 'grpcechoservice.us-east-1.dyntest.netflix.net:8980';
 
-const metadata = netflixGrpcRuntimeCore.netflixGrpcCommon.metadata;
-
-const EchoServiceClient = netflixGrpcRuntimeCore.clientConfigurer
-  .configureClient(echoServices)
-  .withGrpc(grpc)
-  .withPropertiesPrefix('grpc.client.grpcechoservice.EchoService')
-  .withPropertiesStatic({
-    'channel.target': serverEndpoints.dns,
-    'client.pool.rotation.ms': '1000'
-  }).configure();
+function newClient() {
+    return new EchoService(
+        serverDnsAddr,
+        grpc.credentials.createInsecure(),
+        {'grpc.lb_policy_name': 'round_robin'},  // Removing this line eliminates the issue!
+    );
+}
 
 function main() {
-  let numRequests = 0;
+    const clients = [newClient(), newClient()];  // Switch back and forth between two clients.
+    const rotationPeriodMs = 1000;
+    let lastRotation = Date.now();
+    let currentClientIdx = 0;
+    let numRequests = 0;
+    let numResponses = 0;
 
-  const message = new echoMessages();
-  const messageValue = 'gday';
-  message.setValue(messageValue);
-  const client = new EchoServiceClient();
-  setInterval(function () {
-    client.echo(message, function(err, response) {
-        numRequests++;
-        if (err) {
-            console.log(numRequests);
-            console.log(err);
-        } else {
-            process.stdout.write('.');
+    const message = new EchoMessage('salut');
+
+    function sendEcho() {
+        // Switch to a new client if we've exceeded the rotation period.
+        if (Date.now() - lastRotation > rotationPeriodMs) {
+            lastRotation = Date.now();
+            currentClientIdx = (currentClientIdx + 1) % clients.length;
+            clients[currentClientIdx].$channel.close();
+            clients[currentClientIdx] = newClient();
+            console.log(`Rotated client. numResponses/numRequests: ${numResponses}/${numRequests}`);
         }
-    });
-  }, 100);  // 10 rps
+
+        numRequests++;
+        clients[currentClientIdx].echo(message, function(err) {
+            numResponses++;
+            if (err) {
+                console.log(`Error: ${err.message}`);
+            } else {
+                process.stdout.write('.');
+            }
+        });
+    }
+
+    setInterval(sendEcho, 100);  // 10 rps
 }
 
 main();


### PR DESCRIPTION
This updates the repro case for the issue so that it doesn't depend on
Netflix internal libraries.

While working on this it became apparent that the issue seems related
to the `round_robin` load balancer option combined with our pattern
of having multiple clients instantiated for the same server (for
client rotation purposes).